### PR TITLE
DOC: max_errors/1 default value was reported as being both 50 and 100.

### DIFF
--- a/sgml.doc
+++ b/sgml.doc
@@ -220,8 +220,9 @@ holds the text of the processing instruction. Please note that the
 \end{description}
 
 
-The \arg{Options} list controls the conversion process. Currently
-defined options are:
+The \arg{Options} list controls the conversion process.
+Currently defined options are below.
+Other options are passed to sgml_parse/2.
 
 \begin{description}
     \termitem{dtd}{?DTD}
@@ -292,16 +293,6 @@ linenumber to 1.
 
     \termitem{line}{+Line}
 Sets the starting line-number for reporting errors.
-
-    \termitem{max_errors}{+Max}
-Sets the maximum number of errors. If this number is reached, an
-exception of the format below is raised. The default is 50.  Using
-\term{max_errors}{-1} makes the parser continue, no matter how many
-errors it encounters.
-
-	\begin{quote}
-	\term{error}{limit_exceeded(max_errors, Max), _}
-	\end{quote}
 
     \termitem{max_memory}{+Max}
 Sets the maximum buffer size in bytes available for input data and CDATA output. If this limit is reached a resource error is raised. Using \term{max_memory}{0} (the default) means no resource limit will be enforced.
@@ -966,7 +957,14 @@ all open elements.
     \termitem{max_errors}{+MaxErrors}
 Set the maximum number of errors. If this number is exceeded further
 writes to the stream will yield an I/O error exception. Printing of
-errors is suppressed after reaching this value. The default is 100.
+errors is suppressed after reaching this value. The default is 50.
+Using \term{max_errors}{-1} makes the parser continue, no matter how
+many errors it encounters.
+
+	\begin{quote}
+	\term{error}{limit_exceeded(max_errors, Max), _}
+	\end{quote}
+
     \termitem{syntax_errors}{+ErrorMode}
 Defines how syntax errors are handled.
     \begin{description}


### PR DESCRIPTION
DOC: Documented that options of load_structure/3 are passed to sgml_parse/2.