### PR TITLE
accept a free var as specifier, instantiating to index of DOM element

### DIFF
--- a/xpath.pl
+++ b/xpath.pl
@@ -89,6 +89,8 @@ xpath_chk(DOM, Spec, Content) :-
 %
 %	    $ Integer :
 %	    The N-th element with the given name
+%	    $ Variable :
+%	    The N-th element with the given name
 %	    $ =last= :
 %	    The last element with the given name.
 %	    $ =last= - IntExpr :

--- a/xpath.pl
+++ b/xpath.pl
@@ -307,6 +307,9 @@ modifiers([H|T], I, L, Value0, Value) :-
 	modifier(H, I, L, Value0, Value1),
 	modifiers(T, I, L, Value1, Value).
 
+modifier(N, I, _, Value, Value) :-				% allows for *retrieving* index of matched element
+	var(N), integer(I), !,
+	N = I.
 modifier(N, I, _, Value, Value) :-				% Integer
 	integer(N), !,
 	N =:= I.


### PR DESCRIPTION
previous behaviour always (?) instantiated a free var to 'last', now it binds to the index of DOM element, allowing to express easily the relative position of siblings