### PR TITLE
Spelling in xsdp_types.pl

### DIFF
--- a/xsdp_types.pl
+++ b/xsdp_types.pl
@@ -41,7 +41,7 @@
 	  ]).
 
 
-/** <module> XML-Schema primitie types
+/** <module> XML-Schema primitive types
 
 This  modules  provides  support  for  the  primitive  XML-Schema  (XSD)
 datatypes. It defines the type hierarchy which allows for reasoning over


### PR DESCRIPTION
Results in misspelled heading in the [online documentation](http://www.swi-prolog.org/pldoc/doc/swi/library/xsdp_types.pl).