### PR TITLE
FIXED: Functions should be called with is/2.

### DIFF
--- a/xpath.pl
+++ b/xpath.pl
@@ -473,10 +473,10 @@ translate_attr(number, Value0, Value) :-
     xsd_number_string(Value, Value0).
 translate_attr(integer, Value0, Value) :-
     xsd_number_string(Value1, Value0),
-    Value = round(Value1).
+    Value is round(Value1).
 translate_attr(float, Value0, Value) :-
     xsd_number_string(Value1, Value0),
-    Value = float(Value1).
+    Value is float(Value1).
 translate_attr(string, Value0, Value) :-
     atom_string(Value0, Value).
 translate_attr(lower, Value0, Value) :-


### PR DESCRIPTION
Before this fix, the following would bind `N' to `round(123.1)'.
After this fix, `N' is bound to `123' (as intended).

    xpath(Dom, //some_tag(@some_attribute(integer)), N)