### PR TITLE
Keep prefix in attributes

### DIFF
--- a/c14n2.pl
+++ b/c14n2.pl
@@ -171,19 +171,20 @@ put_ns(Name, Name, _, OutNS, OutNS).
 ns_attrs(OutNS, OutNS, []) :- !.
 ns_attrs(OutNS0, OutNS, NSAttrs) :-
     !,
-    dict_keys(OutNS, URLs),
-    dict_keys(OutNS0, URLs0),
-    ord_subtract(URLs, URLs0, NewURLs),
-    maplist(ns_attr(OutNS), NewURLs, NSAttrs0),
+    dict_pairs(OutNS, _, Pairs),
+    dict_pairs(OutNS0, _, Pairs0),
+    ord_subtract(Pairs, Pairs0, NewPairs),
+    maplist(ns_attr(OutNS), NewPairs, NSAttrs0),
     sort(NSAttrs0, NSAttrs).
 
-ns_attr(Dict, URL, NSAttr) :-
+ns_attr(Dict, URL-_, NSAttr) :-
     ns_simplify(xmlns:Dict.URL=URL, NSAttr).
 
 ns_simplify(xmlns:''=URL, xmlns=URL) :- !.
 ns_simplify(xmlns:NS=URL, XMLNS=URL) :-
     make_cname(xmlns:NS, XMLNS).
 
+xml_ns(ns('', xmlns):NS=URL, NS, URL) :- !.
 xml_ns(xmlns=URL, '', URL) :- !.
 xml_ns(xmlns:NS=URL, NS, URL) :- !.
 xml_ns(Name=URL, NS, URL) :-

--- a/xmlns.c
+++ b/xmlns.c
@@ -148,7 +148,7 @@ xmlns_resolve()
 
 int
 xmlns_resolve_attribute(dtd_parser *p, dtd_symbol *id,
-			const ichar **local, const ichar **url)
+                        const ichar **local, const ichar **url, const ichar **prefix)
 { dtd *dtd = p->dtd;
   int nschr = dtd->charfunc->func[CF_NS]; /* : */
   ichar buf[MAXNMLEN];
@@ -166,15 +166,18 @@ xmlns_resolve_attribute(dtd_parser *p, dtd_symbol *id,
 
       if ( istrprefix(L"xml", buf) )	/* XML reserved namespaces */
       { *url = n->name;
+      *prefix = NULL;
         return TRUE;
       } else if ( (ns = xmlns_find(p, n)) )
       { if ( ns->url->name[0] )
 	  *url = ns->url->name;
 	else
-	  *url = NULL;
+          *url = NULL;
+        *prefix = n->name;
 	return TRUE;
       } else
       { *url = n->name;			/* undefined namespace */
+        *prefix = NULL;
 	if ( p->xml_no_ns == NONS_QUIET )
 	  return TRUE;
 	gripe(p, ERC_EXISTENCE, L"namespace", n->name);
@@ -185,6 +188,7 @@ xmlns_resolve_attribute(dtd_parser *p, dtd_symbol *id,
   }
 
   *local = id->name;
+  *prefix = NULL;
 
   if ( (p->flags & SGML_PARSER_QUALIFY_ATTS) &&
        (ns = p->environments->thisns) && ns->url->name[0] )

--- a/xmlns.h
+++ b/xmlns.h
@@ -47,7 +47,7 @@ xmlns *		xmlns_push(dtd_parser *p, const ichar *ns, const ichar *url);
 void		update_xmlns(dtd_parser *p, dtd_element *e,
 			     int natts, sgml_attribute *atts);
 int		xmlns_resolve_attribute(dtd_parser *p, dtd_symbol *id,
-					const ichar **local, const ichar **url);
+                                        const ichar **local, const ichar **url, const ichar **prefix);
 int		xmlns_resolve_element(dtd_parser *p,
                                       const ichar **local, const ichar **url, const ichar **prefix);
 


### PR DESCRIPTION
This changes the behaviour of the parser so that if keep_prefix(true) is specified then _attributes_ also have a ns/2, if appropriate.

It also changes c14n2.pl to deal with these ns/2 objects, including a fix for the case where 2 different prefixes refer to the same URI. For example:

```
<Document xmlns:ns1="some_namespace" ns1:foo="bar">
  <SubDocument  xmlns:ns2="some_namespace" ns2:qux="baz"/>
</Document>
```

The critical point being that xmlns:ns1 and xmlns:ns2 are both 'some_namespace'. Once we have loaded the structure, we cannot tell what 'some_namespace':qux is: Is it ns1 or ns2?
(Of course, the sensible answer of: "Who cares? They're both the same URI!" only applies if you're not trying to make a hash of the result for XML signature verification)