### PR TITLE
FIXED: When sorting namespaces in the element attributes, the critica…

### DIFF
--- a/c14n2.pl
+++ b/c14n2.pl
@@ -104,7 +104,7 @@ xml_canonical_dom(element( Name,  Attrs,  Content),
            ;  Method == 'http://www.w3.org/2001/10/xml-exc-c14n#'
            -> RootNSAttrs1 = NSAttrs
            ;  findall(xmlns:NS=URI, member(xmlns:NS=URI, Attrs), RootNSAttrs, NSAttrs),
-              sort(2, @<, RootNSAttrs, RootNSAttrs1)
+              sort(1, @<, RootNSAttrs, RootNSAttrs1)
            ),
            append([KillDefault, RootNSAttrs1, AttrsSans, AttrsWithNS], CAttrs)
     ;  append([KillDefault, NSAttrs, AttrsSans, AttrsWithNS], CAttrs)


### PR DESCRIPTION
…l thing is that the prefix is sorted, not the URI

I'm pretty sure this should be the first arg, not the second. At least, I get agreement with external tools if I do it this way.

As for tests, I completely agree. There are some tests at https://www.w3.org/TR/xmldsig2ed-tests/#TestCases-C14n11 but actually implementing these in SWI Prolog directly is tricky. Most of the problem comes from distributing namespaces around the tree when you're taking a sub-tree and canonicalizing it, and this doesn't really make sense in our representation.

Still, we could always parse the input as an string, use xpath select the subtree then try to canonicalise it into a new string and check against the reference.

I also worry that this might open a new can of worms :(