### PR TITLE
Do not consider namespaces missing if they are already emitted in kee…

### DIFF
--- a/sgml_write.pl
+++ b/sgml_write.pl
@@ -746,7 +746,8 @@ missing_att_ns([Name=_|T], Def, M0, M) :-
 
 missing_ns(ns(NS, URI):_, Def, M0, M) :-
     !,
-    (  memberchk(NS=URI, Def)
+    ( ( memberchk(NS=URI, Def)
+      ; memberchk(URI, M0) )
     -> M = M0
     ;  NS == ''
     -> M = M0

--- a/sgml_write.pl
+++ b/sgml_write.pl
@@ -672,20 +672,22 @@ add_missing_namespaces(DOM, _, DOM).    % CDATA, etc.
 
 add_missing_ns([], Atts, Atts).
 add_missing_ns([H|T], Atts0, Atts) :-
-    generate_ns(H, NS),
-    add_missing_ns(T, [xmlns:NS=H|Atts0], Atts).
+    generate_ns(H, NS, URL),
+    add_missing_ns(T, [xmlns:NS=URL|Atts0], Atts).
 
-%!  generate_ns(+URI, -NS) is det.
+%!  generate_ns(+URI, -NS, -URL) is det.
 %
 %   Generate a namespace (NS) identifier for URI.
 
-generate_ns(URI, NS) :-
+generate_ns(URI, NS, URI) :-
     xmlns(NS, URI),
     !.
-generate_ns(URI, NS) :-
+generate_ns(ns(NS, URI), NS, URI) :-
+    !.
+generate_ns(URI, NS, URI) :-
     default_ns(URI, NS),
     !.
-generate_ns(_, NS) :-
+generate_ns(URI, NS, URI) :-
     gensym(xns, NS).
 
 %!  xmlns(?NS, ?URI) is nondet.
@@ -746,12 +748,13 @@ missing_att_ns([Name=_|T], Def, M0, M) :-
 
 missing_ns(ns(NS, URI):_, Def, M0, M) :-
     !,
-    ( ( memberchk(NS=URI, Def)
-      ; memberchk(URI, M0) )
+    (   (   memberchk(NS=URI, Def)
+        ;   memberchk(NS=URI, M0)
+        )
     -> M = M0
     ;  NS == ''
     -> M = M0
-    ;  M = [URI|M0]
+    ;  M = [ns(NS, URI)|M0]
     ).
 missing_ns(URI:_, Def, M0, M) :-
     !,


### PR DESCRIPTION
…p_prefix mode

Without this, you get
```
?- xml_write(user_error, element(ns(foo, 'http://www.example.com'):bar, [], [element(ns(foo, 'http://www.example.com'):baz, [], [])]), []).
<?xml version="1.0" encoding="UTF-8"?>

<foo:bar
    xmlns:xns22="http://www.example.com"
    xmlns:xns21="http://www.example.com">
  <foo:baz/>
</foo:bar>
true.
```

With the patch, you get 
```
<foo:bar xmlns:xns19="http://www.google.com">
  <foo:baz/>
</foo:bar>
```

I think this might still be wrong, but it's not _as_ wrong?