### PR TITLE
ADDED: XML C14n tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ swipl_plugin(
 	PL_LIBS ${DTD_FILES}
     THREADED)
 
-test_libs(sgml sgml_write xsd
+test_libs(sgml sgml_write xsd c14n
 	  TEST_DIRS Test)
 
 pkg_doc(sgml

--- a/c14n2.pl
+++ b/c14n2.pl
@@ -153,6 +153,8 @@ put_elemns(Name, Name, _InNS, OutNS0, OutNS1, [xmlns='']) :-
 put_elemns(Name, CName, InNS, OutNS0, OutNS, []) :-
     put_ns(Name, CName, InNS, OutNS0, OutNS).
 
+put_ns(ns('', xml):Name, xml:Name, _InNS, OutNS, OutNS) :-
+    !.
 put_ns(ns(NS, URL):Name, CName, _InNS, OutNS, OutNS) :-
     get_dict(URL, OutNS, NS),
     !,

--- a/test_c14n.pl
+++ b/test_c14n.pl
@@ -1,0 +1,159 @@
+/*  Part of SWI-Prolog
+
+    Author:        Matt Lilley
+    E-mail:        matt.lilley@securitease.com
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2013-2020, University of Amsterdam
+                              VU University Amsterdam
+                              CWI, Amsterdam
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(test_c14n,
+          [ test_c14n/0
+          ]).
+
+:- use_module(library(c14n2)).
+
+test_c14n :-
+    run_tests([ c14n ]).
+
+:-begin_tests(c14n).
+
+
+%!  xml_file(+File, -Absolute)
+%
+%   Find an absolute path to the xml sample data in the `testdata` directory.
+
+xml_file(File, Abs) :-
+    source_file(test_c14n, MyFile),
+    file_directory_name(MyFile, MyDir),
+    atomic_list_concat([MyDir, File], /, Abs).
+
+%!  c14n_test(+InputFile, +XPath, +TargetFile).
+%
+%   Canonicalize the document obtained by applying the XPath expression to
+%   the document specified by InputFile and confirm it matches exactly the
+%   bytes in TargetFile.
+
+c14n_test(InputFile, XPath, TargetFile):-
+        xml_file(InputFile, InputFilename),
+        xml_file(TargetFile, TargetFilename),
+        setup_call_cleanup(open(InputFilename, read, InputStream),
+                           load_structure(InputStream, InputDocument, [dialect(xmlns), space(preserve), keep_prefix(true)]),
+                           close(InputStream)),
+        setup_call_cleanup(open(TargetFilename, read, TargetStream),
+                           read_string(TargetStream, _, TargetDocument),
+                           close(TargetStream)),
+        findall(SubDocument,
+                xpath(InputDocument, XPath, SubDocument),
+                SubDocuments),
+        with_output_to(string(GeneratedDocument),
+                       forall(member(SubDocument, SubDocuments),
+                              xml_write_canonical(current_output, SubDocument, [method('http://www.w3.org/2001/10/xml-exc-c14n#')]))),
+        TargetDocument == GeneratedDocument.
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+These tests are derived from the w3c tests available at
+https://www.w3.org/TR/xmldsig2ed-tests/#TestCases-C14n11
+The input/target documents are stored in testdata/
+The xpath expressions are encoded inline in the tests. This is because the
+SWI-Prolog implementation of xpath is not syntax-compatible with the w3c one
+The test names include the section of the source document they pertain to
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+test('3.2.1.1 Test case c14n11/xmllang-1'):-
+        c14n_test('testdata/xmllang-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmllang-1.output').
+
+test('3.2.1.2 Test case c14n11/xmllang-2'):-
+        c14n_test('testdata/xmllang-input.xml', //(ns(ietf, 'http://www.ietf.org'):e2), 'xmllang-2.output').
+
+test('3.2.1.3 Test case c14n11/xmllang-3'):-
+        c14n_test('testdata/xmllang-input.xml', //(ns(ietf, 'http://www.ietf.org'):e11), 'xmllang-3.output').
+
+test('3.2.1.4 Test case c14n11/xmllang-4'):-
+        % FIXME: How to encode (//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11 or ancestor-or-self::ietf:e12]
+        c14n_test('testdata/xmllang-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmllang-4.output').
+
+test('3.2.2.1 Test case c14n11/xmlspace-1'):-
+        c14n_test('testdata/xmlspace-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmlspace-1.output').
+
+test('3.2.2.2 Test case c14n11/xmlspace-2'):-
+        c14n_test('testdata/xmlspace-input.xml', //(ns(ietf, 'http://www.ietf.org'):e2), 'xmlspace-2.output').
+
+test('3.2.2.3 Test case c14n11/xmlspace-3'):-
+        c14n_test('testdata/xmlspace-input.xml', //(ns(ietf, 'http://www.ietf.org'):e11), 'xmlspace-3.output').
+
+test('3.2.2.4 Test case c14n11/xmlspace-4'):-
+        % FIXME: How to encode (//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11 or ancestor-or-self::ietf:e12]
+        c14n_test('testdata/xmlspace-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmlspace-4.output').
+
+test('3.2.3.1 Test case c14n11/xmlid-1'):-
+        c14n_test('testdata/xmlid-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmlid-1.output').
+
+test('3.2.3.2 Test case c14n11/xmlid-2'):-
+        % FIXME: How to encode (//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11 or ancestor-or-self::ietf:e12]
+        c14n_test('testdata/xmlid-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmlid-2.output').
+
+test('3.2.4.1,1 Test case c14n11/xmlbase-prop-1'):-
+        % FIXME: How to encode (//. | //@* | //namespace::*) [ancestor-or-self::ietf:c14n11XmlBaseDoc1 and not(ancestor-or-self::ietf:e2)]
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmlbase-prop-1.output').
+
+test('3.2.4.1.2 Test case c14n11/xmlbase-prop-2'):-
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e1), 'xmlbase-prop-2.output').
+
+test('3.2.4.1.3 Test case c14n11/xmlbase-prop-3'):-
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e11), 'xmlbase-prop-3.output').
+
+test('3.2.4.1.4 Test case c14n11/xmlbase-prop-4'):-
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e111), 'xmlbase-prop-4.output').
+
+test('3.2.4.1.5 Test case c14n11/xmlbase-prop-5'):-
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e21), 'xmlbase-prop-5.output').
+
+test('3.2.4.1.6 Test case c14n11/xmlbase-prop-6'):-
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e3), 'xmlbase-prop-6.output').
+
+test('3.2.4.1.7 Test case c14n11/xmlbase-prop-7'):-
+        % FIXME: How to encode (//. | //@* | //namespace::*) [ancestor-or-self::ietf:c14n11XmlBaseDoc1 and not(ancestor-or-self::ietf:e1 or ancestor-or-self::ietf:e2)]
+        c14n_test('testdata/xmlbase-prop-input.xml', //(ns(ietf, 'http://www.ietf.org'):e3), 'xmlbase-prop-7.output').
+
+test('3.2.4.2.1 Test case c14n11/xmlbase-c14n11spec-102'):-
+        % FIXME: (//. | //@* | //namespace::*)[self::ietf:e1 or (parent::ietf:e1 and not(self::text() or self::e2)) or count(id("E3")|ancestor-or-self::node()) = count(ancestor-or-self::node())]
+        c14n_test('testdata/xmlbase-c14n11spec-input.xml', //(ns(ietf, 'http://www.ietf.org'):e3), 'xmlbase-c14n11spec-102.output').
+
+test('3.2.4.2.2 Test case c14n11/xmlbase-c14n11spec-102'):-
+        % FIXME: (//. | //@* | //namespace::*)[self::ietf:e1 or (parent::ietf:e1 and not(self::text() or self::e2)) or count(id("E3")|ancestor-or-self::node()) = count(ancestor-or-self::node())]
+        c14n_test('testdata/xmlbase-c14n11spec2-input.xml', //(ns(ietf, 'http://www.ietf.org'):e3), 'xmlbase-c14n11spec2-102.output').
+
+test('3.2.4.2.3 Test case c14n11/xmlbase-c14n11spec-102'):-
+        % FIXME: (//. | //@* | //namespace::*) [self::a or ancestor-or-self::d]
+        c14n_test('testdata/xmlbase-c14n11spec3-input.xml', //(ns(ietf, 'http://www.ietf.org'):e3), 'xmlbase-c14n11spec3-102.output').
+
+
+:-end_tests(c14n).

--- a/testdata/xmlbase-c14n11spec-102.output
+++ b/testdata/xmlbase-c14n11spec-102.output
@@ -1,0 +1,1 @@
+<e1 xmlns="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://www.example.com/something/else"><e3 xmlns="" id="E3" xml:base="../bar/foo" xml:space="preserve"></e3></e1>

--- a/testdata/xmlbase-c14n11spec-input.xml
+++ b/testdata/xmlbase-c14n11spec-input.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE doc [
+<!ATTLIST e2 xml:space (default|preserve) 'preserve'>
+<!ATTLIST e3 id ID #IMPLIED>
+]>
+<doc xmlns="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://www.example.com/something/else">
+   <e1>
+      <e2 xmlns="" xml:id="abc" xml:base="../bar/">
+         <e3 id="E3" xml:base="foo"/>
+      </e2>
+   </e1>
+</doc>

--- a/testdata/xmlbase-c14n11spec2-102.output
+++ b/testdata/xmlbase-c14n11spec2-102.output
@@ -1,0 +1,1 @@
+<e1 xmlns="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="something/else"><e3 xmlns="" id="E3" xml:base="bar/foo" xml:space="preserve"></e3></e1>

--- a/testdata/xmlbase-c14n11spec2-input.xml
+++ b/testdata/xmlbase-c14n11spec2-input.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE doc [
+<!ATTLIST e2 xml:space (default|preserve) 'preserve'>
+<!ATTLIST e3 id ID #IMPLIED>
+]>
+<doc xmlns="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="something/else">
+   <e1>
+      <e2 xmlns="" xml:id="abc" xml:base="bar/">
+         <e3 id="E3" xml:base="foo"/>
+      </e2>
+   </e1>
+</doc>

--- a/testdata/xmlbase-c14n11spec3-103.output
+++ b/testdata/xmlbase-c14n11spec3-103.output
@@ -1,0 +1,2 @@
+<a xml:base="foo/bar"><d xml:base="../../x">
+   </d></a>

--- a/testdata/xmlbase-c14n11spec3-input.xml
+++ b/testdata/xmlbase-c14n11spec3-input.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a xml:base="foo/bar">
+ <b xml:base="..">
+  <c xml:base="..">
+   <d xml:base="x">
+   </d>
+  </c>
+ </b>
+</a>

--- a/testdata/xmlbase-prop-1-exc.output
+++ b/testdata/xmlbase-prop-1-exc.output
@@ -1,0 +1,14 @@
+<ietf:c14n11XmlBaseDoc1 xmlns:ietf="http://www.ietf.org" xml:base="http://xmlbase.example.org/xmlbase0/">
+  <ietf:e1 xml:base="/xmlbase1/">
+    <ietf:e11 xml:base="/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"></ietf:e111>
+    </ietf:e11>
+    <ietf:e12 at="2">
+      <ietf:e121 xml:base="/xmlbase121/"></ietf:e121>
+    </ietf:e12>
+  </ietf:e1>
+  
+  <ietf:e3>
+    <ietf:e31 at="3"></ietf:e31>
+  </ietf:e3>
+</ietf:c14n11XmlBaseDoc1>

--- a/testdata/xmlbase-prop-1.output
+++ b/testdata/xmlbase-prop-1.output
@@ -1,0 +1,14 @@
+<ietf:c14n11XmlBaseDoc1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase0/">
+  <ietf:e1 xml:base="/xmlbase1/">
+    <ietf:e11 xml:base="/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"></ietf:e111>
+    </ietf:e11>
+    <ietf:e12 at="2">
+      <ietf:e121 xml:base="/xmlbase121/"></ietf:e121>
+    </ietf:e12>
+  </ietf:e1>
+  
+  <ietf:e3>
+    <ietf:e31 at="3"></ietf:e31>
+  </ietf:e3>
+</ietf:c14n11XmlBaseDoc1>

--- a/testdata/xmlbase-prop-1.xpath
+++ b/testdata/xmlbase-prop-1.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:c14n11XmlBaseDoc1 and not(ancestor-or-self::ietf:e2)]</XPath>

--- a/testdata/xmlbase-prop-2-exc.output
+++ b/testdata/xmlbase-prop-2-exc.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xml:base="/xmlbase1/">
+    <ietf:e11 xml:base="/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"></ietf:e111>
+    </ietf:e11>
+    <ietf:e12 at="2">
+      <ietf:e121 xml:base="/xmlbase121/"></ietf:e121>
+    </ietf:e12>
+  </ietf:e1>

--- a/testdata/xmlbase-prop-2.output
+++ b/testdata/xmlbase-prop-2.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase1/">
+    <ietf:e11 xml:base="/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"></ietf:e111>
+    </ietf:e11>
+    <ietf:e12 at="2">
+      <ietf:e121 xml:base="/xmlbase121/"></ietf:e121>
+    </ietf:e12>
+  </ietf:e1>

--- a/testdata/xmlbase-prop-2.xpath
+++ b/testdata/xmlbase-prop-2.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e1]</XPath>

--- a/testdata/xmlbase-prop-3-exc.output
+++ b/testdata/xmlbase-prop-3-exc.output
@@ -1,0 +1,3 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xml:base="/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"></ietf:e111>
+    </ietf:e11>

--- a/testdata/xmlbase-prop-3.output
+++ b/testdata/xmlbase-prop-3.output
@@ -1,0 +1,3 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"></ietf:e111>
+    </ietf:e11>

--- a/testdata/xmlbase-prop-3.xpath
+++ b/testdata/xmlbase-prop-3.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11]</XPath>

--- a/testdata/xmlbase-prop-4-exc.output
+++ b/testdata/xmlbase-prop-4-exc.output
@@ -1,0 +1,1 @@
+<ietf:e111 xmlns:ietf="http://www.ietf.org" xml:base="/xmlbase111/"></ietf:e111>

--- a/testdata/xmlbase-prop-4.output
+++ b/testdata/xmlbase-prop-4.output
@@ -1,0 +1,1 @@
+<ietf:e111 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase111/"></ietf:e111>

--- a/testdata/xmlbase-prop-4.xpath
+++ b/testdata/xmlbase-prop-4.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e111]</XPath>

--- a/testdata/xmlbase-prop-5-exc.output
+++ b/testdata/xmlbase-prop-5-exc.output
@@ -1,0 +1,1 @@
+<ietf:e21 xmlns:ietf="http://www.ietf.org" xml:base="/xmlbase21/"></ietf:e21>

--- a/testdata/xmlbase-prop-5.output
+++ b/testdata/xmlbase-prop-5.output
@@ -1,0 +1,1 @@
+<ietf:e21 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase21/"></ietf:e21>

--- a/testdata/xmlbase-prop-5.xpath
+++ b/testdata/xmlbase-prop-5.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e21]</XPath>

--- a/testdata/xmlbase-prop-6-exc.output
+++ b/testdata/xmlbase-prop-6-exc.output
@@ -1,0 +1,3 @@
+<ietf:e3 xmlns:ietf="http://www.ietf.org">
+    <ietf:e31 at="3"></ietf:e31>
+  </ietf:e3>

--- a/testdata/xmlbase-prop-6.output
+++ b/testdata/xmlbase-prop-6.output
@@ -1,0 +1,3 @@
+<ietf:e3 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase0/">
+    <ietf:e31 at="3"></ietf:e31>
+  </ietf:e3>

--- a/testdata/xmlbase-prop-6.xpath
+++ b/testdata/xmlbase-prop-6.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e3]</XPath>

--- a/testdata/xmlbase-prop-7-exc.output
+++ b/testdata/xmlbase-prop-7-exc.output
@@ -1,0 +1,7 @@
+<ietf:c14n11XmlBaseDoc1 xmlns:ietf="http://www.ietf.org" xml:base="http://xmlbase.example.org/xmlbase0/">
+  
+  
+  <ietf:e3>
+    <ietf:e31 at="3"></ietf:e31>
+  </ietf:e3>
+</ietf:c14n11XmlBaseDoc1>

--- a/testdata/xmlbase-prop-7.output
+++ b/testdata/xmlbase-prop-7.output
@@ -1,0 +1,7 @@
+<ietf:c14n11XmlBaseDoc1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase0/">
+  
+  
+  <ietf:e3>
+    <ietf:e31 at="3"></ietf:e31>
+  </ietf:e3>
+</ietf:c14n11XmlBaseDoc1>

--- a/testdata/xmlbase-prop-7.xpath
+++ b/testdata/xmlbase-prop-7.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:c14n11XmlBaseDoc1 and not(ancestor-or-self::ietf:e1 or ancestor-or-self::ietf:e2)]</XPath>

--- a/testdata/xmlbase-prop-input.xml
+++ b/testdata/xmlbase-prop-input.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ietf:c14n11XmlBaseDoc1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:base="http://xmlbase.example.org/xmlbase0/">
+  <ietf:e1 xml:base="/xmlbase1/">
+    <ietf:e11 xml:base="/xmlbase11/">
+      <ietf:e111 xml:base="/xmlbase111/"/>
+    </ietf:e11>
+    <ietf:e12 at="2">
+      <ietf:e121 xml:base="/xmlbase121/"/>
+    </ietf:e12>
+  </ietf:e1>
+  <ietf:e2>
+    <ietf:e21 xml:base="/xmlbase21/"/>
+  </ietf:e2>
+  <ietf:e3>
+    <ietf:e31 at="3"/>
+  </ietf:e3>
+</ietf:c14n11XmlBaseDoc1>

--- a/testdata/xmlid-1-exc.output
+++ b/testdata/xmlid-1-exc.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xml:id="IdInterop">
+      <ietf:e11>
+         <ietf:e111></ietf:e111>
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>
+   </ietf:e1>

--- a/testdata/xmlid-1.output
+++ b/testdata/xmlid-1.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:id="IdInterop">
+      <ietf:e11>
+         <ietf:e111></ietf:e111>
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>
+   </ietf:e1>

--- a/testdata/xmlid-1.xpath
+++ b/testdata/xmlid-1.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e1]</XPath>

--- a/testdata/xmlid-2-exc.output
+++ b/testdata/xmlid-2-exc.output
@@ -1,0 +1,5 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org">
+         <ietf:e111></ietf:e111>
+      </ietf:e11><ietf:e12 xmlns:ietf="http://www.ietf.org" at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>

--- a/testdata/xmlid-2.output
+++ b/testdata/xmlid-2.output
@@ -1,0 +1,5 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org">
+         <ietf:e111></ietf:e111>
+      </ietf:e11><ietf:e12 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>

--- a/testdata/xmlid-2.xpath
+++ b/testdata/xmlid-2.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11 or ancestor-or-self::ietf:e12]</XPath>

--- a/testdata/xmlid-input.xml
+++ b/testdata/xmlid-input.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ietf:c14n11XmlIdDoc1 xmlns:ietf="http://www.ietf.org" 
+xmlns:w3c="http://www.w3.org">
+   <ietf:e1 xml:id="IdInterop">
+      <ietf:e11>
+         <ietf:e111 />
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121 />
+      </ietf:e12>
+   </ietf:e1>
+   <ietf:e2 >
+      <ietf:e21 />
+   </ietf:e2>  
+</ietf:c14n11XmlIdDoc1>

--- a/testdata/xmllang-1-exc.output
+++ b/testdata/xmllang-1-exc.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xml:lang="EN">
+      <ietf:e11>
+         <ietf:e111></ietf:e111>
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>
+   </ietf:e1>

--- a/testdata/xmllang-1.output
+++ b/testdata/xmllang-1.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:lang="EN">
+      <ietf:e11>
+         <ietf:e111></ietf:e111>
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>
+   </ietf:e1>

--- a/testdata/xmllang-1.xpath
+++ b/testdata/xmllang-1.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*)[ancestor-or-self::ietf:e1]</XPath>

--- a/testdata/xmllang-2-exc.output
+++ b/testdata/xmllang-2-exc.output
@@ -1,0 +1,3 @@
+<ietf:e2 xmlns:ietf="http://www.ietf.org">
+      <ietf:e21></ietf:e21>
+   </ietf:e2>

--- a/testdata/xmllang-2.output
+++ b/testdata/xmllang-2.output
@@ -1,0 +1,3 @@
+<ietf:e2 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org">
+      <ietf:e21></ietf:e21>
+   </ietf:e2>

--- a/testdata/xmllang-2.xpath
+++ b/testdata/xmllang-2.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*)[ancestor-or-self::ietf:e2]</XPath>

--- a/testdata/xmllang-3-exc.output
+++ b/testdata/xmllang-3-exc.output
@@ -1,0 +1,3 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org">
+         <ietf:e111></ietf:e111>
+      </ietf:e11>

--- a/testdata/xmllang-3.output
+++ b/testdata/xmllang-3.output
@@ -1,0 +1,3 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:lang="EN">
+         <ietf:e111></ietf:e111>
+      </ietf:e11>

--- a/testdata/xmllang-3.xpath
+++ b/testdata/xmllang-3.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*)[ancestor-or-self::ietf:e11]</XPath>

--- a/testdata/xmllang-4-exc.output
+++ b/testdata/xmllang-4-exc.output
@@ -1,0 +1,5 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org">
+         <ietf:e111></ietf:e111>
+      </ietf:e11><ietf:e12 xmlns:ietf="http://www.ietf.org" at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>

--- a/testdata/xmllang-4.output
+++ b/testdata/xmllang-4.output
@@ -1,0 +1,5 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:lang="EN">
+         <ietf:e111></ietf:e111>
+      </ietf:e11><ietf:e12 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" at="2" xml:lang="EN">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>

--- a/testdata/xmllang-4.xpath
+++ b/testdata/xmllang-4.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*)[ancestor-or-self::ietf:e11 or ancestor-or-self::ietf:e12]</XPath>

--- a/testdata/xmllang-input.xml
+++ b/testdata/xmllang-input.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ietf:c14n11Xmllang xmlns:ietf="http://www.ietf.org" 
+xmlns:w3c="http://www.w3.org">
+   <ietf:e1 xml:lang="EN">
+      <ietf:e11>
+         <ietf:e111 />
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121 />
+      </ietf:e12>
+   </ietf:e1>
+   <ietf:e2 >
+      <ietf:e21 />
+   </ietf:e2>
+</ietf:c14n11Xmllang>

--- a/testdata/xmlspace-1-exc.output
+++ b/testdata/xmlspace-1-exc.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xml:space="true">
+      <ietf:e11>
+         <ietf:e111></ietf:e111>
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>
+   </ietf:e1>

--- a/testdata/xmlspace-1.output
+++ b/testdata/xmlspace-1.output
@@ -1,0 +1,8 @@
+<ietf:e1 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:space="true">
+      <ietf:e11>
+         <ietf:e111></ietf:e111>
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>
+   </ietf:e1>

--- a/testdata/xmlspace-1.xpath
+++ b/testdata/xmlspace-1.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e1]</XPath>

--- a/testdata/xmlspace-2-exc.output
+++ b/testdata/xmlspace-2-exc.output
@@ -1,0 +1,3 @@
+<ietf:e2 xmlns:ietf="http://www.ietf.org">
+      <ietf:e21></ietf:e21>
+   </ietf:e2>

--- a/testdata/xmlspace-2.output
+++ b/testdata/xmlspace-2.output
@@ -1,0 +1,3 @@
+<ietf:e2 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org">
+      <ietf:e21></ietf:e21>
+   </ietf:e2>

--- a/testdata/xmlspace-2.xpath
+++ b/testdata/xmlspace-2.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e2]</XPath>

--- a/testdata/xmlspace-3-exc.output
+++ b/testdata/xmlspace-3-exc.output
@@ -1,0 +1,3 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org">
+         <ietf:e111></ietf:e111>
+      </ietf:e11>

--- a/testdata/xmlspace-3.output
+++ b/testdata/xmlspace-3.output
@@ -1,0 +1,3 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:space="true">
+         <ietf:e111></ietf:e111>
+      </ietf:e11>

--- a/testdata/xmlspace-3.xpath
+++ b/testdata/xmlspace-3.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11]</XPath>

--- a/testdata/xmlspace-4-exc.output
+++ b/testdata/xmlspace-4-exc.output
@@ -1,0 +1,5 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org">
+         <ietf:e111></ietf:e111>
+      </ietf:e11><ietf:e12 xmlns:ietf="http://www.ietf.org" at="2">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>

--- a/testdata/xmlspace-4.output
+++ b/testdata/xmlspace-4.output
@@ -1,0 +1,5 @@
+<ietf:e11 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" xml:space="true">
+         <ietf:e111></ietf:e111>
+      </ietf:e11><ietf:e12 xmlns:ietf="http://www.ietf.org" xmlns:w3c="http://www.w3.org" at="2" xml:space="true">
+         <ietf:e121></ietf:e121>
+      </ietf:e12>

--- a/testdata/xmlspace-4.xpath
+++ b/testdata/xmlspace-4.xpath
@@ -1,0 +1,1 @@
+<XPath xmlns:ietf="http://www.ietf.org">(//. | //@* | //namespace::*) [ancestor-or-self::ietf:e11 or ancestor-or-self::ietf:e12]</XPath>

--- a/testdata/xmlspace-input.xml
+++ b/testdata/xmlspace-input.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ietf:c14n11XmlSpaceDoc1 xmlns:ietf="http://www.ietf.org" 
+xmlns:w3c="http://www.w3.org">
+   <ietf:e1 xml:space="true">
+      <ietf:e11>
+         <ietf:e111 />
+      </ietf:e11>
+      <ietf:e12 at="2">
+         <ietf:e121 />
+      </ietf:e12>
+   </ietf:e1>
+   <ietf:e2 >
+      <ietf:e21 />
+   </ietf:e2>
+</ietf:c14n11XmlSpaceDoc1>


### PR DESCRIPTION
This PR adds 20 tests (of which 3 are blocked because they involve very complicated xpath expressions) plus a bug fix for xml:lang not forcing xmlns="xml" in the output.

The tests are derived from https://www.w3.org/TR/xmldsig2ed-tests/#TestCases-C14n11 but converted from inclusive to exclusive canonicalization tests.