### PR TITLE
SECURITY: Potential buffer overflow when raising gripes involving fil…

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -2727,7 +2727,7 @@ static void
 validate_completeness(dtd_parser *p, sgml_environment *env)
 { if ( !complete(env) )
   { wchar_t buf[MAXNMLEN+50];
-
+    memset(buf, 0, sizeof(buf));
     swprintf(buf, MAXNMLEN+50, L"Incomplete element: <%s>",
 	     env->element->name->name);
 
@@ -5527,6 +5527,7 @@ format_message(dtd_error *e)
   wchar_t *end = &s[MAX_MESSAGE_LEN];
   size_t prefix_len;
 
+  memset(buf, 0, sizeof(buf));
   switch(e->severity)
   { case ERS_ERROR:
       wcscpy(s, L"Error: ");
@@ -5587,6 +5588,7 @@ gripe(dtd_parser *p, dtd_error_id e, ...)
   int dtdmode = FALSE;
   void *freeme = NULL;
 
+  memset(buf, 0, sizeof(buf));
   va_start(args, e);
 
   memset(&error, 0, sizeof(error));


### PR DESCRIPTION
…es with very long filenames (such as files loaded via a URL with a long search parameter). It turns out that swprintf does not always append a NULL if the buffer is too short - it does on macOS but not on minGW or Ubuntu

To address this, I pre-fill the entire buffer with \0 via memset. Then, even if the swprintf() fails to return a positive value, at least wcslen() will think the buffer size is within the bounds of the buffer.