### PR TITLE
Prevent double-free in model generation on failure

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -2068,8 +2068,7 @@ make_model(dtd_parser *p, const ichar *decl, const ichar **end)
       modeltype mt;
 
       if ( !(sub = make_model(p, decl, &s)) )
-      { free_model(sub);
-	return NULL;
+      { return NULL;
       }
       decl = s;
       add_submodel(m, sub);


### PR DESCRIPTION
If make_model() returns a falsy value, it does not make sense to then… try and free it. In fact, make_model already cleans up any structures if it is going to return a failure status.

Fixes #93 