### PR TITLE
Allow user to explicitly disable DOCTYPE processing

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -3972,7 +3972,7 @@ process_declaration(dtd_parser *p, const ichar *decl)
     else if ( (s = isee_identifier(dtd, decl, "sgml")) )
       process_sgml_declaration(p, s);
     else if ( (s = isee_identifier(dtd, decl, "doctype")) )
-    { if ( p->dmode != DM_DTD )
+    { if ( p->dmode != DM_DTD && !p->ignore_doctype )
 	process_doctype(p, s, decl-1);
     } else
     { s = iskip_layout(dtd, decl);

--- a/parser.h
+++ b/parser.h
@@ -196,6 +196,7 @@ typedef struct _dtd_parser
   int	   first;			/* Just seen <tag> */
   int	   waiting_for_net;		/* waiting for / in <shorttag/mode/ */
   size_t max_memory;			/* maximum buffer size */
+  int      ignore_doctype;              /* If 1, ignore doctype declarations */
   icharbuf *buffer;			/* buffer for temp data */
   ocharbuf *cdata;			/* collected character data */
   int	   blank_cdata;			/* CDATA is all blank */

--- a/sgml.doc
+++ b/sgml.doc
@@ -297,6 +297,9 @@ Sets the starting line-number for reporting errors.
     \termitem{max_memory}{+Max}
 Sets the maximum buffer size in bytes available for input data and CDATA output. If this limit is reached a resource error is raised. Using \term{max_memory}{0} (the default) means no resource limit will be enforced.
 
+    \termitem{ignore_doctype}{+Bool}
+If set, doctype declarations in the document will be ignored. This can help prevent XXE attacks
+
     \termitem{cdata}{+Representation}
 Specify the representation of \jargon{cdata} elements. Supported are
 \const{atom} (default), and \const{string}. The choice is not obvious.

--- a/sgml.pl
+++ b/sgml.pl
@@ -113,6 +113,7 @@
                        case_preserving_attributes(boolean),
                        system_entities(boolean),
                        max_memory(integer),
+                       ignore_doctype(boolean),
                        space(oneof([sgml,preserve,default,remove,strict])),
                        xmlns(atom),
                        xmlns(atom,atom),
@@ -491,6 +492,7 @@ parser_option(case_sensitive_attributes(_)).
 parser_option(case_preserving_attributes(_)).
 parser_option(system_entities(_)).
 parser_option(max_memory(_)).
+parser_option(ignore_doctype(_)).
 parser_option(file(_)).
 parser_option(line(_)).
 parser_option(space(_)).

--- a/sgml2pl.c
+++ b/sgml2pl.c
@@ -183,6 +183,7 @@ static functor_t FUNCTOR_case_sensitive_attributes1;
 static functor_t FUNCTOR_case_preserving_attributes1;
 static functor_t FUNCTOR_system_entities1;
 static functor_t FUNCTOR_max_memory1;
+static functor_t FUNCTOR_ignore_doctype1;
 static functor_t FUNCTOR_qualify_attributes1;
 static functor_t FUNCTOR_encoding1;
 static functor_t FUNCTOR_xmlns1;
@@ -230,6 +231,7 @@ initConstants()
   FUNCTOR_dialect1	 = mkfunctor("dialect", 1);
   FUNCTOR_keep_prefix1	 = mkfunctor("keep_prefix", 1);
   FUNCTOR_max_errors1	 = mkfunctor("max_errors", 1);
+  FUNCTOR_ignore_doctype1 = mkfunctor("ignore_doctype", 1);
   FUNCTOR_parse1	 = mkfunctor("parse", 1);
   FUNCTOR_source1	 = mkfunctor("source", 1);
   FUNCTOR_content_length1= mkfunctor("content_length", 1);
@@ -610,6 +612,15 @@ pl_set_sgml_parser(term_t parser, term_t option)
       p->buffer->limit = val;
     if ( p->cdata )
       p->cdata->limit = val;
+  } else if ( PL_is_functor(option, FUNCTOR_ignore_doctype1 ) )
+  { term_t a = PL_new_term_ref();
+    int val;
+
+    _PL_get_arg(1, option, a);
+    if ( !PL_get_bool(a, &val) )
+      return sgml2pl_error(ERR_TYPE, "boolean", a);
+
+    p->ignore_doctype = val;
   } else if ( PL_is_functor(option, FUNCTOR_number1) )
   { term_t a = PL_new_term_ref();
     char *s;


### PR DESCRIPTION
Add ignore_doctype(+Bool) option to explicitly ignore DOCTYPEs embedded in XML

Implements #95 