### PR TITLE
CLEANUP: Use snprintf to avoid deprecation warnings

### DIFF
--- a/error.c
+++ b/error.c
@@ -156,7 +156,7 @@ sgml2pl_error(plerrorid id, ...)
     { const char *id = va_arg(args, const char *);
       const char *fmt = va_arg(args, const char *);
 
-      vsprintf(msgbuf, fmt, args);
+      vsnprintf(msgbuf, sizeof msgbuf, fmt, args);
       msg = msgbuf;
 
       rc = PL_unify_term(formal,

--- a/quote.c
+++ b/quote.c
@@ -242,7 +242,7 @@ do_quote(term_t in, term_t quoted, const char **map, int maxchr)
       } else if ( c > maxchr )
       { char buf[20];
 
-	sprintf(buf, "&#%d;", c);
+	snprintf(buf, sizeof buf, "&#%d;", c);
 	if ( !add_str_buf(&buffer, buf) )
 	  return FALSE;
 


### PR DESCRIPTION
I just saw that this should be labeled cleanup, not port